### PR TITLE
Use Guard defined in Nova config

### DIFF
--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -26,7 +26,7 @@ class Note extends Model
 
     public function createdBy()
     {
-        $userClass = config('auth.providers.users.model');
+        $userClass = config('auth.providers.' . config('auth.guards.' . config('nova.guard') . '.provider') . '.model');
         return $this->belongsTo($userClass, 'created_by');
     }
 

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -26,7 +26,14 @@ class Note extends Model
 
     public function createdBy()
     {
-        $userClass = config('auth.providers.' . config('auth.guards.' . config('nova.guard') . '.provider') . '.model');
+        $provider = 'users';
+        
+        if(config('nova.guard')) {
+            $provider = config('auth.guards.' . config('nova.guard') . '.provider')
+        }
+
+        $userClass = config('auth.providers.' . $provider . '.model');
+
         return $this->belongsTo($userClass, 'created_by');
     }
 

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -29,7 +29,7 @@ class Note extends Model
         $provider = 'users';
         
         if(config('nova.guard')) {
-            $provider = config('auth.guards.' . config('nova.guard') . '.provider')
+            $provider = config('auth.guards.' . config('nova.guard') . '.provider');
         }
 
         $userClass = config('auth.providers.' . $provider . '.model');


### PR DESCRIPTION
Thanks to this change current User model is not hardcoded, also it inherits guard from Nova config which is used for entire authentication.

Use case: Admin as a separated model.