### PR TITLE
Add class to maintain text formatting

### DIFF
--- a/resources/js/notes-field/components/Note.vue
+++ b/resources/js/notes-field/components/Note.vue
@@ -30,7 +30,7 @@
       </div>
 
       <!-- Content -->
-      <p v-html="note.text"></p>
+      <p v-html="note.text" class="whitespace-pre-wrap"></p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Added class attribute in the `<!--content-->` `<p>` element so that the text maintains the formatting inserted in the textarea without using HTML tags.