### PR TITLE
Added ability to use model attribute for the avatar url

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The available configuration option(s):
 
 | Config            | Type     | description                                                                                                                                                  |
 | ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| get_avatar_url    | callable | Callable which allows you to generate your own URL for the user. The input parameter is the user model. By default, Gravatar is used for the user's avatars. |
+| get_avatar_url    | callable or string | Either enter the url attribute name on your model or a callable which allows you to generate your own URL for the user. The input parameter is the user model. By default, Gravatar is used for the user's avatars. |
 | table_name        | string   | Optionally provide your own table name for the notes table. Default is `nova_notes`.                                                                         |
 | notes_model       | string   | Optionally provide your own Note model.                                                                                                                      |
 | date_format       | string   | Optionally provide custom moment.js compatible date format.                                                                                                  |

--- a/config/nova-notes-field.php
+++ b/config/nova-notes-field.php
@@ -25,23 +25,25 @@ return [
 
     'notes_model' => \OptimistDigital\NovaNotesField\Models\Note::class,
 
-
     /*
     |--------------------------------------------------------------------------
     | Avatar URL
     |--------------------------------------------------------------------------
     |
-    | Callable which allows you to generate your own URL for the user. The
-    | input parameter is the user model. By default, Gravatar is used
-    | for the user's avatars.
+    | Return the model attribute that accesses the avatar url.
     |
-    | For example:
-    | 'get_avatar_url' => fn ($user) => $user->getAvatarUrl(),
+    | For example
+    | 'get_avatar_url' => 'avatar_url',
+    |
+    | This assumes that you have the following on your User model:
+    | public function getAvatarUrlAttribute(): string
+    | {
+    |   //Code to return the correct avatar url
+    | }
     |
     */
 
     'get_avatar_url' => null,
-
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -49,8 +49,11 @@ class Note extends Model
         $createdBy = $this->createdBy;
         if (empty($createdBy)) return null;
 
-        $avatarCallable = config('nova-notes-field.get_avatar_url', null);
-        if (is_callable($avatarCallable)) return call_user_func($avatarCallable, $createdBy);
+        $avatarUrl = config('nova-notes-field.get_avatar_url', null);
+        if ($avatarUrl) {
+            if (is_callable($avatarUrl)) return call_user_func($avatarUrl, $createdBy);
+            return $createdBy->$avatarUrl;
+        }
 
         return 'https://www.gravatar.com/avatar/' . md5(strtolower($createdBy->email)) . '?s=300';
     }


### PR DESCRIPTION
This is a fix for issue #29.

The 'get_avatar_url' entry in config can now be used to return a callable **or** the avatar url attribute name on the model.

